### PR TITLE
Improve restart and fix skippcount

### DIFF
--- a/bin/mpstop
+++ b/bin/mpstop
@@ -1,32 +1,37 @@
 #! /bin/bash
-if [ -f /tmp/mixplayd.pid ]; then
-  PID=$(cat /tmp/mixplayd.pid)
-  LIST=$(ps -fea)
-  LIST=$(echo -e "${LIST}" | grep mixplayd)
-  RES=$(echo -e "${LIST}" | grep ${PID})
-  if [ "${RES}" != "" ]; then
-      echo "Stopping mixplayd.."
-      kill ${PID}
-      if [ $? != 0 ]; then
-          echo "Error while stopping mixplayd.."
-          echo -n "${LIST}"
-          exit
-      fi
-      for i in {1..5}; do
-        sleep 1
-        if [ ! -f /tmp/mixplayd.pid ]; then
-          exit
+
+function mpstopper() {
+  if [ -f /tmp/mixplayd.pid ]; then
+    PID=$(cat /tmp/mixplayd.pid)
+    LIST=$(ps -fea)
+    LIST=$(echo -e "${LIST}" | grep mixplayd)
+    RES=$(echo -e "${LIST}" | grep ${PID})
+    if [ "${RES}" != "" ]; then
+        echo "Stopping mixplayd.."
+        kill ${PID}
+        if [ $? != 0 ]; then
+            echo "Error while stopping mixplayd.."
+            echo -n "${LIST}"
+            exit
         fi
-      done
-      echo "Killing mixplayd!"
-      kill -9 ${PID}
+        for i in {1..5}; do
+          sleep 1
+          if [ ! -f /tmp/mixplayd.pid ]; then
+            return
+          fi
+        done
+        echo "Killing mixplayd!"
+        kill -9 ${PID}
+    else
+      echo "mixplayd(${PID}) does not exist!"
+    fi
+    rm -f /tmp/mixplayd.pid
   else
-    echo "mixplayd(${PID}) does not exist!"
+    echo "mixplayd is not running!"
   fi
-  rm -f /tmp/mixplayd.pid
-else
-  echo "mixplayd is not running!"
-fi
+}
+
+mpstopper
 
 if [ "$1" = "-r" ]; then
   RP=$(realpath $0)

--- a/src/config.c
+++ b/src/config.c
@@ -751,7 +751,7 @@ void setCurrentActivity( const char* activity ) {
 		strtcpy(_curact, activity, MP_ACTLEN);
 		notifyChange(MPCOMM_TITLES);
 		if(getDebug() > 1) {
-			printf("* %s\n", _curact);
+			printf("\r* %s\n", _curact);
 		}
 	}
 }

--- a/src/mixplay.html
+++ b/src/mixplay.html
@@ -80,7 +80,7 @@
         <button id='reload' onclick='document.location.reload()'>Reload client</button>
         <button id='debug'  onclick='toggleDebug()'>Enable Debug</button>
         <div id='debugdiv' class='hide'>
-          <p id='status' class='hide'></p>
+          <p id='status'></p>
           <button id='reset'   onclick='showConfirm("Confirm restart", 0x1f)'>Reset player</button>
           <button id='playcnt' onclick='showKbd(0x12)'>Fix playcount</button>
           <button id='rescan'  onclick='showKbd(0x08)'>Rescan</button>

--- a/src/mixplayd.c
+++ b/src/mixplayd.c
@@ -256,7 +256,8 @@ int32_t main(int32_t argc, char **argv) {
 			pthread_join(control->rtid, NULL);
 			addMessage(1, "Reader stopped");
 			if (control->watchdog >= WATCHDOG_TIMEOUT) {
-				addMessage(1, "Restarting after timeout");
+				addMessage(1, "Restarting after timeout cooldown");
+				sleep(1);
 				initAll();
 			}
 		} while (control->watchdog >= WATCHDOG_TIMEOUT);

--- a/src/musicmgr.c
+++ b/src/musicmgr.c
@@ -1553,6 +1553,7 @@ static int32_t addNewTitle(void) {
 		if (guard != runner) {
 			/* title did not fit, start again from the beginning
 			 * with the new one that fits here */
+			addMessage(1, "Testing %s", runner->display);
 			while (pl->next != NULL) {
 				pl = pl->next;
 			}

--- a/src/musicmgr.c
+++ b/src/musicmgr.c
@@ -1418,8 +1418,8 @@ void setArtistSpread() {
 	mptitle_t *checker=NULL;
 	uint32_t count=0;
 
-	unsetFlags(MP_TDARK);
-	unsetFlags(MP_PDARK);
+	/* make sure all titles are caught */
+	unsetFlags(MP_TDARK|MP_PDARK);
 	setCurrentActivity("Checking artist spread");
 	while (runner != NULL) {
 		checker=skipOver(runner->next,1);

--- a/src/player.c
+++ b/src/player.c
@@ -550,6 +550,7 @@ static void *killPlayers(pid_t pid[2], int32_t p_command[2][2],
 	mpconfig_t *control = getConfig();
 	uint32_t players = (control->fade > 0) ? 2 : 1;
 
+	addMessage(0, "Stopping player");
 	if (restart) {
 		addMessage(MPV + 1, "kill and restart reader");
 		control->watchdog = WATCHDOG_TIMEOUT;


### PR DESCRIPTION
restarting the players on stream errors is still flaky. Some delays and checks have been added to improve the situation

adding titles when only 1 title is left will cause and endless loop since a zero step skippcount() will return the original title which may be marked T_DARK. The selection of titles has been improved so the boundaries get adapted whenever playcount gets increased or max repeats gets lowered.