### PR TITLE
fix deadlock in msgbuf on clear

### DIFF
--- a/src/mpserver.c
+++ b/src/mpserver.c
@@ -70,10 +70,10 @@ static uint32_t _heartbeat[MAXCLIENT];	/* glabal clientID marker */
 
 /* return an unused clientid
    this gives out clientids in ascending order, even if a previous clientid
-	 is already free again. This is done to avoid mobile clients reconnecting
-	 with their old clientid causing mix-ups if that id was already recycled.
-	 It still may happen but there nedd to be ~100 connects while the client
-	 was offline. Good enough for now */
+   is already free again. This is done to avoid mobile clients reconnecting
+   with their old clientid causing mix-ups if that id was already recycled.
+   It still may happen but there nedd to be ~100 connects while the client
+   was offline. Good enough for now */
 static int32_t getFreeClient(void) {
 	static uint32_t maxclientid = 0;
 	int32_t i;

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -2,6 +2,7 @@
 #define __MSGBUF_H__ 1
 #include <pthread.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #define MSGNUM 20
 
@@ -20,6 +21,7 @@ typedef struct {
 	uint64_t count;				/* the number of the last message */
 	int32_t unread;				/* the number of never read messages */
 	pthread_mutex_t *msgLock;	/* mutex to control access to the messages */
+	bool shutdown;
 } msgbuf_t;
 
 /**
@@ -27,10 +29,8 @@ typedef struct {
  */
 msgbuf_t *msgBuffInit();
 uint64_t msgBuffAdd(msgbuf_t * msgbuf, char *line);
-clmessage *msgBuffGet(msgbuf_t * msgbuf);
 const clmessage *msgBuffPeek(msgbuf_t * msgbuf, uint64_t msgno);
 char *msgBuffAll(msgbuf_t * msgbuf);
-void msgBuffClear(msgbuf_t * msgbuf);
 void msgBuffDiscard(msgbuf_t * msgbuf);
 uint64_t msgBufGetLastRead(msgbuf_t * msgbuf);
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -266,15 +266,17 @@ char *fetchline(FILE * fp) {
 /**
  * reads from the fd into the line buffer until either a CR
  * comes or the fd stops sending characters.
- * returns number of read bytes or -1 on overflow.
+ * returns number of read bytes, -1 on overflow or 0 if
+ * no data was sent. This means that reading a line containing 
+ * of a carriage return will return 1 (as one character was read)
  */
-int32_t readline(char *line, size_t len, int32_t fd) {
+size_t readline(char *line, size_t len, int fd) {
 	size_t cnt = 0;
 	char c;
 
 	while (0 != read(fd, &c, 1)) {
 		if (cnt < len) {
-			if ('\n' == c) {
+			if ('\n' || '\r' == c) {
 				c = 0;
 			}
 
@@ -286,7 +288,7 @@ int32_t readline(char *line, size_t len, int32_t fd) {
 			}
 		}
 		else {
-			return -1;
+			return (size_t) -1;
 		}
 	}
 
@@ -294,7 +296,8 @@ int32_t readline(char *line, size_t len, int32_t fd) {
 	/* this code should never be reached but maybe there is */
 	/* a read() somewhere that timeouts.. */
 	line[cnt] = 0;
-	cnt++;
+	if (cnt > 0)
+		cnt++;
 
 	return cnt;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,7 +44,7 @@ bool startsWith(const char *text, const char *prefix);
 bool isURL(const char *uri);
 bool isDir(const char *path);
 char *fetchline(FILE * fp);
-int32_t readline(char *line, size_t len, int32_t fd);
+size_t readline(char *line, size_t len, int fd);
 char *abspath(char *path, const char *basedir, const size_t len);
 void *falloc(size_t num, size_t size);
 void *frealloc(void *old, size_t size);


### PR DESCRIPTION
when cleaning up the msgbug it may happen that some code still wants to access the buffer. Now those calls will just return NULL.

update readline() function