### PR TITLE
set thread names for enhanced debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ SRCDIR=src
 OBJDIR=build
 
 CCFLAGS+=-DVERSION=\"$(VERSION)\"
+CCFLAGS+=-D_GNU_SOURCE -std=gnu11 -Wall -Wextra -Werror -pedantic -I .
 
 ifdef MPDEBUG
 # force compilation with -g
-CCFLAGS+=-std=gnu11 -Wall -Wextra -pedantic -Werror -I . -g
+CCFLAGS+=-g
 ifeq ($(MPDEBUG),2)
 # enable address sanitizer
 CCFLAGS+=-fsanitize=address
@@ -16,9 +17,9 @@ endif
 else
 # master branch is built with -O2, dev branches with -g
 ifeq ($(shell git rev-parse --abbrev-ref HEAD),master)
-CCFLAGS+=-std=gnu11 -Wall -Wextra -Werror -pedantic -I . -O2
+CCFLAGS+=-O2
 else
-CCFLAGS+=-std=gnu11 -Wall -Wextra -pedantic -Werror -I . -g
+CCFLAGS+=-g
 endif
 endif
 

--- a/src/config.c
+++ b/src/config.c
@@ -921,8 +921,8 @@ bool isDebug(void) {
  *
  * this may block to make sure the state is sane
  */
-int32_t playerIsBusy(void) {
-	int32_t res = 0;
+bool playerIsBusy(void) {
+	bool res = 0;
 	mpconfig_t *control = getConfig();
 
 	res = (control->status == mpc_start) || (control->mpmode & PM_SWITCH);

--- a/src/config.h
+++ b/src/config.h
@@ -245,7 +245,7 @@ void wipeSearchList(mpconfig_t *);
 
 mptitle_t *wipeTitles(mptitle_t * root);
 marklist_t *wipeList(marklist_t * root);
-int32_t playerIsBusy(void);
+bool playerIsBusy(void);
 void blockSigint();
 
 int32_t getNotify(int32_t);

--- a/src/controller.c
+++ b/src/controller.c
@@ -9,7 +9,6 @@
  *	  Author: bweber
  */
 
-#include <pthread.h>
 #include <errno.h>
 #include <unistd.h>
 
@@ -304,6 +303,9 @@ static void asyncRun(void *cmd(void *)) {
 
 	if (pthread_create(&pid, NULL, cmd, &_asynclock) < 0) {
 		addMessage(0, "Could not create async thread!");
+	}
+	else {
+		pthread_setname_np(pid, "tmpcmdhndlr");
 	}
 }
 

--- a/src/mixplayd.c
+++ b/src/mixplayd.c
@@ -254,6 +254,7 @@ int32_t main(int32_t argc, char **argv) {
 		if (getDebug()) {
 			addUpdateHook(&_debugHidUpdateHook);
 			pthread_create(&hidtid, NULL, debugHID, NULL);
+			pthread_setname_np(hidtid, "debugHID");
 		}
 		addUpdateHook(&_volumeUpdateHook);
 

--- a/src/mpflirc.c
+++ b/src/mpflirc.c
@@ -55,6 +55,7 @@ pthread_t startFLIRC(int32_t fd) {
 		addMessage(0, "Could not create mpHID thread!");
 		return -1;
 	}
+	pthread_setname_np(tid, "mpFLIRC");
 	return tid;
 }
 

--- a/src/mphid.h
+++ b/src/mphid.h
@@ -1,6 +1,5 @@
 #ifndef __MPHID_H__
 #define __MPHID_H__ 1
-#include <pthread.h>
 #include "config.h"
 
 mpcmd_t hidCMD(int32_t c);

--- a/src/mpinit.c
+++ b/src/mpinit.c
@@ -147,9 +147,11 @@ int32_t initAll() {
 
 	/* start the actual player */
 	pthread_create(&control->rtid, NULL, reader, NULL);
+	pthread_setname_np(control->rtid, "player");
 
 	/* Runs as thread to have updates in the UI */
 	pthread_create(&tid, NULL, setProfile, NULL);
+	pthread_setname_np(tid, "init_setProfile");
 	pthread_detach(tid);
 
 	return 0;

--- a/src/mpserver.c
+++ b/src/mpserver.c
@@ -16,7 +16,6 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <netdb.h>
 #include <poll.h>
 
@@ -943,6 +942,9 @@ static void *mpserver(void *arg) {
 				(&pid, NULL, clientHandler, (void *) (long) client_sock) < 0) {
 				addMessage(0, "Could not create client handler thread!");
 			}
+			else {
+				pthread_setname_np(pid, "clientHandler");
+			}
 		}
 	}
 	addMessage(0, "Server stopped");
@@ -1045,6 +1047,7 @@ int32_t startServer() {
 	addMessage(MPV + 1, "bind() done");
 
 	pthread_create(&control->stid, NULL, mpserver, (void *) (long) mainsocket);
+	pthread_setname_np(control->stid, "mpserver");
 
 	return 0;
 }

--- a/src/musicmgr.c
+++ b/src/musicmgr.c
@@ -1433,11 +1433,6 @@ static int32_t addNewTitle(void) {
 	maxpcount = getPlaycount(true);
 	addMessage(2, "Playcount [%" PRIu32 ":%" PRIu32 "]", pcount, maxpcount);
 
-	/* Do not unset the TDARK flag while still filling up the playlist */
-	if (countflag(MP_INPL) > MIN(num, 10)) {
-		unsetFlags(MP_TDARK);
-	}
-
 	/* are there playable titles at all? */
 	if (countTitles(getFavplay()? MP_FAV : MP_ALL, MP_HIDE) == 0) {
 		fail(F_FAIL, "No titles to be played!");
@@ -1639,6 +1634,7 @@ void plCheck(bool fill) {
 
 	/* fill up the playlist with new titles */
 	if (fill) {
+		unsetFlags(MP_TDARK);
 		while (cnt < 10) {
 			activity(0, "Add title %i", cnt);
 			addNewTitle();

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,6 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include <pthread.h>
 #include <termios.h>
 #include <assert.h>
 #include <linux/input.h>
@@ -276,7 +275,12 @@ size_t readline(char *line, size_t len, int fd) {
 
 	while (0 != read(fd, &c, 1)) {
 		if (cnt < len) {
-			if ('\n' || '\r' == c) {
+			// skip CR to properly digest CR/LF
+			if (c == '\r') {
+				continue;
+			}
+			// LR means line end
+			if (c == '\n') {
 				c = 0;
 			}
 


### PR DESCRIPTION
* clean up Makefile and add _GNU_SOURCE to enable pthread_setname_np 
* bool-ify playerIsBusy()
* clean up #include<pthread.h> instances
* unset MP_TDARK only after playlist has actually changed 
* fix bug in readline() which broke everything
