### PR TITLE
Lineout volume switch

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -985,13 +985,14 @@ profile_t *addProfile(const char *name, const char *url, bool newid) {
 	profile_t *profile = (profile_t *) falloc(1, sizeof (profile_t));
 
 	profile->name = strdup(name);
+	profile->volume = DEFAULT_VOLUME;
 	if (url != NULL) {
 		profile->url = strdup(url);
 	}
 	else {
 		profile->url = NULL;
+		profile->volume += VOLUME_PROFILE;
 	}
-	profile->volume = DEFAULT_VOLUME;
 	if (newid) {
 		_cconfig->maxid++;
 		profile->id = _cconfig->maxid;

--- a/src/config.c
+++ b/src/config.c
@@ -988,10 +988,10 @@ profile_t *addProfile(const char *name, const char *url, bool newid) {
 	profile->volume = DEFAULT_VOLUME;
 	if (url != NULL) {
 		profile->url = strdup(url);
+		profile->volume += VOLUME_STREAM;
 	}
 	else {
 		profile->url = NULL;
-		profile->volume += VOLUME_PROFILE;
 	}
 	if (newid) {
 		_cconfig->maxid++;

--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,8 @@
 #define FADESECS 4
 
 #define DEFAULT_VOLUME (90)
+/* default line out adaption for local MP3 play */
+#define VOLUME_PROFILE (+5)
 
 /*
  * commands and states

--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,7 @@
 /* standard crossfade value */
 #define FADESECS 4
 
-#define DEFAULT_VOLUME (90)
+#define DEFAULT_VOLUME (100)
 /* default line out adaption for local MP3 play */
 #define VOLUME_STREAM (-10)
 
@@ -217,7 +217,8 @@ mpplaylist_t *getCurrent();
 profile_t *getProfile(uint32_t id);
 int32_t getProfileIndex(uint32_t id);
 bool isStream(profile_t * profile);
-bool isStreamId(uint32_t id);
+
+#define isStreamActive() isStream(getProfile(getConfig()->active))
 
 void incDebug(void);
 int32_t getDebug(void);

--- a/src/config.h
+++ b/src/config.h
@@ -22,8 +22,8 @@
 /* standard crossfade value */
 #define FADESECS 4
 
-#define DEFAULT_VOLUME (100)
-/* default line out adaption for local MP3 play */
+#define DEFAULT_VOLUME (90)
+/* default line out adaption for internet stream play */
 #define VOLUME_STREAM (-10)
 
 /*

--- a/src/config.h
+++ b/src/config.h
@@ -181,6 +181,7 @@ typedef struct {
 	uint32_t spread;
 	uint32_t maxid;				/* highest profile id */
 	uint32_t lineout;			/* enable line-out at fix volume */
+	int32_t linestream;			/* stream play volume modifier */
 	uint32_t fade;				/* controls fading between titles */
 	/* flags for mpmode */
 	uint32_t searchDNP:1;

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,7 @@
 
 #define DEFAULT_VOLUME (90)
 /* default line out adaption for local MP3 play */
-#define VOLUME_PROFILE (+5)
+#define VOLUME_STREAM (-10)
 
 /*
  * commands and states

--- a/src/controller.c
+++ b/src/controller.c
@@ -549,13 +549,6 @@ void setCommand(mpcmd_t rcmd, char *arg) {
 			addMessage(-1, "No name given!");
 		}
 		else if ((config->current != NULL) && asyncTest()) {
-			int32_t cvol = config->volume;
-
-			if (cvol < 0)
-				cvol = DEFAULT_VOLUME;
-			profile_t *profile = addProfile(arg, config->streamURL, true);
-
-			profile->volume = cvol;
 			writeConfig(NULL);
 			pthread_mutex_unlock(&_asynclock);
 			notifyChange(MPCOMM_CONFIG);

--- a/src/controller.c
+++ b/src/controller.c
@@ -561,7 +561,7 @@ void setCommand(mpcmd_t rcmd, char *arg) {
 		}
 		else if ((config->current != NULL) && asyncTest()) {
 			/* only clone profiles */
-			if (!isStreamId(config->active)) {
+			if (!isStreamActive()) {
 				if (copyProfile(config->active, arg) > 0) {
 					writeList(mpc_fav);
 					writeList(mpc_dnp);

--- a/src/controller.c
+++ b/src/controller.c
@@ -549,6 +549,7 @@ void setCommand(mpcmd_t rcmd, char *arg) {
 			addMessage(-1, "No name given!");
 		}
 		else if ((config->current != NULL) && asyncTest()) {
+			addProfile(arg, config->streamURL, true);
 			writeConfig(NULL);
 			pthread_mutex_unlock(&_asynclock);
 			notifyChange(MPCOMM_CONFIG);

--- a/src/mpalsa.c
+++ b/src/mpalsa.c
@@ -159,7 +159,7 @@ long controlVolume(long volume, bool absolute) {
 		retval = LINEOUT;
 		newvol = config->lineout;
 
-		if (isStream(getProfile(config->active)))
+		if (isStreamActive())
 			newvol += VOLUME_STREAM;
 	}
 	snd_mixer_selem_set_playback_volume_all(_elem, (newvol * max) / 100);

--- a/src/mpalsa.c
+++ b/src/mpalsa.c
@@ -149,22 +149,21 @@ long controlVolume(long volume, bool absolute) {
 		retval += volume;
 	}
 
+	if (retval < 0)
+		retval = 0;
+	if (retval > 100)
+		retval = 100;
+	uint32_t newvol = retval;
+
 	if (config->lineout > 0) {
 		retval = LINEOUT;
-		uint32_t linevol = config->lineout;
+		newvol = config->lineout;
 
 		if (!isStream(getProfile(config->active)))
-			linevol += VOLUME_PROFILE;
-		snd_mixer_selem_set_playback_volume_all(_elem,
-												(config->lineout * max) / 100);
+			newvol += VOLUME_PROFILE;
+		addMessage(1, "Set lineout volume to %d", newvol);
 	}
-	else {
-		if (retval < 0)
-			retval = 0;
-		if (retval > 100)
-			retval = 100;
-		snd_mixer_selem_set_playback_volume_all(_elem, (retval * max) / 100);
-	}
+	snd_mixer_selem_set_playback_volume_all(_elem, (newvol * max) / 100);
 	config->volume = retval;
 	return retval;
 }

--- a/src/mpalsa.c
+++ b/src/mpalsa.c
@@ -138,7 +138,7 @@ long controlVolume(long volume, bool absolute) {
 	}
 
 	snd_mixer_selem_get_playback_volume_range(_elem, &min, &max);
-	if (absolute != 0) {
+	if (absolute) {
 		retval = volume;
 	}
 	else {
@@ -159,9 +159,8 @@ long controlVolume(long volume, bool absolute) {
 		retval = LINEOUT;
 		newvol = config->lineout;
 
-		if (!isStream(getProfile(config->active)))
-			newvol += VOLUME_PROFILE;
-		addMessage(1, "Set lineout volume to %d", newvol);
+		if (isStream(getProfile(config->active)))
+			newvol += VOLUME_STREAM;
 	}
 	snd_mixer_selem_set_playback_volume_all(_elem, (newvol * max) / 100);
 	config->volume = retval;

--- a/src/mpalsa.c
+++ b/src/mpalsa.c
@@ -151,6 +151,10 @@ long controlVolume(long volume, bool absolute) {
 
 	if (config->lineout > 0) {
 		retval = LINEOUT;
+		uint32_t linevol = config->lineout;
+
+		if (!isStream(getProfile(config->active)))
+			linevol += VOLUME_PROFILE;
 		snd_mixer_selem_set_playback_volume_all(_elem,
 												(config->lineout * max) / 100);
 	}

--- a/src/player.c
+++ b/src/player.c
@@ -244,7 +244,6 @@ void *setProfile(void *arg) {
 
 	notifyChange(MPCOMM_CONFIG);
 
-	setVolume(profile->volume);
 	startPlayer();
 
 	/* make sure that progress messages are removed */
@@ -889,6 +888,7 @@ void *reader( __attribute__ ((unused))
 								writeConfig(NULL);
 								oactive = control->active;
 							}
+							setVolume(getProfile(control->active)->volume);
 						}
 						control->status = mpc_play;
 						notifyChange(MPCOMM_CONFIG);

--- a/src/player.c
+++ b/src/player.c
@@ -244,7 +244,6 @@ void *setProfile(void *arg) {
 
 	notifyChange(MPCOMM_CONFIG);
 
-//  usleep(500);                // why?
 	setVolume(profile->volume);
 	startPlayer();
 


### PR DESCRIPTION
Commonly streams are 'louder' than local MP3s, so add a volume modifier to control that difference when using line-out mode.